### PR TITLE
Create a construction point for aligning bevel gears.

### DIFF
--- a/GFGearGenerator.py
+++ b/GFGearGenerator.py
@@ -675,6 +675,11 @@ def sketchcon(x,y,x2,y2,z,z2,rp,rp2,rf,ra,Ttda,m,aok, newComp):
         linepp=lines.addByTwoPoints(puntocon,puntop)
         linecenter=lines.addByTwoPoints(puntosup,puntocon)
 
+        pointInput = rootComp.constructionPoints.createInput()
+        pointInput.setByTwoEdges(linead, linepp)
+        conpoint = rootComp.constructionPoints.add(pointInput)
+        conpoint.name = "Align Point"
+
         path=newComp.features.createPath(linepp, False)
         guiderail=newComp.features.createPath(linead, False)
 


### PR DESCRIPTION
Currently it's a bit of a pain to align bevel gears once they are generated. This PR adds construction points to bevel gears that make aligning them trivial. Simply use the align tool to make the 'Align Point' on two matched bevel gears overlap, and you're most of the way there! You may have to use the 'flip' option in the align tool to make the gear targeted by the align operation land in the right spot. After that all you should need to do is rotate one of the gears by the pitch angle to make them mesh properly.

Note the example below is for miter gears (i.e. bevel gears of the same size and tooth count) but I have also tested it with bevel gears of differing sizes and the process is the same.

![ex1](https://github.com/CenturySturgeon/GF-Gear-Generator/assets/6798456/93ebcc4f-02f0-4254-bf65-91b0ed14d0b8)

![ex2](https://github.com/CenturySturgeon/GF-Gear-Generator/assets/6798456/3b899aee-1e71-45b0-9b32-d84da40e8271)

![ex3](https://github.com/CenturySturgeon/GF-Gear-Generator/assets/6798456/d771c8dc-927b-4aa6-868c-4c109afe0a7b)
